### PR TITLE
fixed bugged out delete function

### DIFF
--- a/src/controllers/session.controller.js
+++ b/src/controllers/session.controller.js
@@ -48,22 +48,18 @@ const deleteSession = async (req, res, next) => {
         const authToken = req.headers.authorization.replace("Bearer ", "");
         const user = AuthService.verifyToken(authToken);
         
-        const session = await SessionService.getSession({
-            id: sessionId
-        });
+        const sessionExists = await SessionService.sessionExistsForIdAndUser(
+            sessionId,
+            user.id
+        );
 
-        if (!session) {
+        if (!sessionExists) {
             res.status(404).json({ nxtGenStatus: 1, error: 'session not found' });
             return;
         }
-
-        if (user.id != session.user_id) {
-            res.status(401).json({ nxtGenStatus: 1, error: 'session doesn\'t belong to the user' });
-            return;
-        }
         
-        await session.destroy();
-
+        await SessionService.deleteSession(sessionId);
+        
         res.status(200).json({nxtGenStatus: 0, 'result' : 'success'})
 
     } catch (error) {

--- a/src/service/session.service.js
+++ b/src/service/session.service.js
@@ -27,6 +27,22 @@ class SessionService {
         return false;
     }
 
+    static async sessionExistsForIdAndUser(sessionId, userId) {
+        const session = await Session.findOne({
+            where: {
+                id: sessionId,
+                user_id: userId,
+            }
+        })
+
+        console.log(session);
+
+        if (session != null || session != undefined)
+            return true;
+        
+        return false;
+    }
+
     static async getSessions(filters){
 
         const type = filters.type;
@@ -52,6 +68,16 @@ class SessionService {
         })
         return sessions;
     }
-}
+
+    static async deleteSession(sessionId) {
+        const session = await Session.findOne({
+            where: {
+                id: sessionId
+            }
+        });
+
+        await session.destroy();
+    }
+} 
 
 module.exports = SessionService


### PR DESCRIPTION
- Added sessionExistsForIdAndUser to check if a session exists and it belongs to the user trying to access it
- Added deleteSession separately to allow deletion of a session
- deleting a session now returns 404 even if the session exists but the session doesn't belong to the token user